### PR TITLE
Add convenience functions for listing/checking time zones

### DIFF
--- a/lib/nerves_time_zones.ex
+++ b/lib/nerves_time_zones.ex
@@ -47,4 +47,20 @@ defmodule NervesTimeZones do
   """
   @spec tz_environment() :: %{String.t() => String.t()}
   defdelegate tz_environment, to: NervesTimeZones.Server
+
+  @doc """
+  Return all known time zones
+
+  This function scans the time zone database each time it's called. It's
+  not slow, but if you just need to verify whether a time zone exists,
+  call `valid_time_zone?/1` instead.
+  """
+  @spec time_zones() :: [String.t()]
+  defdelegate time_zones(), to: Zoneinfo
+
+  @doc """
+  Return whether a time zone is valid
+  """
+  @spec valid_time_zone?(String.t()) :: boolean
+  defdelegate valid_time_zone?(time_zone), to: Zoneinfo
 end

--- a/test/nerves_time_zones_test.exs
+++ b/test/nerves_time_zones_test.exs
@@ -30,6 +30,19 @@ defmodule NervesTimeZonesTest do
     assert %{"TZDIR" => path, "TZ" => Path.join(path, tz)} == NervesTimeZones.tz_environment()
   end
 
+  test "valid_time_zone?/1" do
+    assert NervesTimeZones.valid_time_zone?("America/Chicago")
+    refute NervesTimeZones.valid_time_zone?("Luna/Mare_Tranquilitatis")
+    refute NervesTimeZones.valid_time_zone?("")
+  end
+
+  test "time_zones/0" do
+    tz_list = NervesTimeZones.time_zones()
+
+    assert "Africa/Nairobi" in tz_list
+    refute "" in tz_list
+  end
+
   test "sets Calendar TimeZoneDatabase" do
     # The database isn't set in our config.exs. NervesTimeZones sets it
     assert Calendar.get_time_zone_database() == Zoneinfo.TimeZoneDatabase


### PR DESCRIPTION
These delegate to Zoneinfo, but the user doesn't need to know that. They
can just be concerned with only calling into NervesTimeZones if they
want.
