### PR TITLE
Sanity check all time zones

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,7 @@ defmodule NervesTimeZones.MixProject do
 
   defp deps do
     [
-      {:zoneinfo, "~> 0.1.0"},
+      {:zoneinfo, "~> 0.1.2"},
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},
       {:dialyxir, "~> 1.1.0", only: :dev, runtime: false},
       {:elixir_make, "~> 0.6", runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,5 @@
   "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
-  "zoneinfo": {:hex, :zoneinfo, "0.1.1", "c3b29e536c56ff724c379444258b56406c85c0fbd025a6f3d71e89f801c32a8e", [:mix], [], "hexpm", "f5bfce5e434e3e5a3e1f14308d14dc0f0ee49675b577d27f349de5e24df1f8e8"},
+  "zoneinfo": {:hex, :zoneinfo, "0.1.2", "4b4609c7200fc0cd15e723db10062342929accca5092079758456e39bb6b8a2e", [:mix], [], "hexpm", "cc96475f47a1577cd6977210b4d85bbb1d2fb74cfa1a91e9d66ae2d155d34b6a"},
 }

--- a/test/nerves_time_zones_test.exs
+++ b/test/nerves_time_zones_test.exs
@@ -39,6 +39,10 @@ defmodule NervesTimeZonesTest do
   test "time_zones/0" do
     tz_list = NervesTimeZones.time_zones()
 
+    # This probably changes with tzdata releases, but if it's not in this
+    # range, it would be good to double check the database generation.
+    assert_in_delta length(tz_list), 472, 10
+
     assert "Africa/Nairobi" in tz_list
     refute "" in tz_list
   end

--- a/test/tzdata_test.exs
+++ b/test/tzdata_test.exs
@@ -1,0 +1,21 @@
+defmodule TzdataTest do
+  use ExUnit.Case, async: true
+
+  @year 365 * 24 * 60 * 60
+  @day 24 * 60 * 60
+
+  # Check that records are available from now until 10 years from now
+  # The "- 31 * @day" part is to avoid failing on old database builds.
+  @earliest_record_after NaiveDateTime.utc_now()
+  @latest_record_after NaiveDateTime.add(NaiveDateTime.utc_now(), 10 * @year - 31 * @day)
+
+  for time_zone <- NervesTimeZones.time_zones() do
+    test "metadata for #{time_zone}" do
+      {:ok, meta} = Zoneinfo.get_metadata(unquote(time_zone))
+
+      # These tests check that records were generated for the requested range
+      assert NaiveDateTime.compare(@earliest_record_after, meta.earliest_record_utc) == :gt
+      assert NaiveDateTime.compare(@latest_record_after, meta.latest_record_utc) == :lt
+    end
+  end
+end


### PR DESCRIPTION
This runs a test over all generated tzif files to ensure they contain
data convering the expected date range.
