### PR TITLE
Move config to init_args

### DIFF
--- a/lib/nerves_time_zones.ex
+++ b/lib/nerves_time_zones.ex
@@ -39,6 +39,14 @@ defmodule NervesTimeZones do
   defdelegate get_time_zone(), to: NervesTimeZones.Server
 
   @doc """
+  Reset the time zone to the default
+
+  This cleans up any saved time zone information and reapplies the defaults.
+  """
+  @spec reset_time_zone() :: :ok
+  defdelegate reset_time_zone(), to: NervesTimeZones.Server
+
+  @doc """
   Return environment variables for running OS processes
 
   If you're using `System.cmd/3` to start an OS process that is time zone

--- a/lib/nerves_time_zones/application.ex
+++ b/lib/nerves_time_zones/application.ex
@@ -5,8 +5,10 @@ defmodule NervesTimeZones.Application do
 
   @impl Application
   def start(_type, _args) do
+    init_args = Application.get_all_env(:nerves_time_zones)
+
     children = [
-      {NervesTimeZones.Server, []}
+      {NervesTimeZones.Server, init_args}
     ]
 
     opts = [strategy: :one_for_one, name: NervesTimeZones.Supervisor]

--- a/lib/nerves_time_zones/persistence.ex
+++ b/lib/nerves_time_zones/persistence.ex
@@ -3,9 +3,8 @@ defmodule NervesTimeZones.Persistence do
 
   @file_name "localtime"
 
-  @spec(save_time_zone(String.t()) :: :ok, {:error, any()})
-  def save_time_zone(time_zone) do
-    data_dir = data_directory()
+  @spec(save_time_zone(Path.t(), String.t()) :: :ok, {:error, any()})
+  def save_time_zone(data_dir, time_zone) do
     path = Path.join(data_dir, @file_name)
 
     with :ok <- File.mkdir_p(data_dir) do
@@ -13,16 +12,16 @@ defmodule NervesTimeZones.Persistence do
     end
   end
 
-  @spec load_time_zone() :: {:ok, String.t()} | {:error, any()}
-  def load_time_zone() do
-    Path.join(data_directory(), @file_name)
+  @spec load_time_zone(Path.t()) :: {:ok, String.t()} | {:error, any()}
+  def load_time_zone(data_dir) do
+    Path.join(data_dir, @file_name)
     |> File.read()
     |> sanity_check()
   end
 
-  @spec reset() :: :ok | {:error, atom}
-  def reset() do
-    Path.join(data_directory(), @file_name)
+  @spec reset(Path.t()) :: :ok | {:error, atom}
+  def reset(data_dir) do
+    Path.join(data_dir, @file_name)
     |> File.rm()
   end
 
@@ -40,9 +39,5 @@ defmodule NervesTimeZones.Persistence do
     n = byte_size(time_zone)
 
     n > 0 and n < 255 and String.valid?(time_zone)
-  end
-
-  defp data_directory() do
-    Application.get_env(:nerves_time_zones, :data_dir, "/data/nerves_time_zones")
   end
 end

--- a/test/nerves_time_zones_test.exs
+++ b/test/nerves_time_zones_test.exs
@@ -5,11 +5,15 @@ defmodule NervesTimeZonesTest do
   import ExUnit.CaptureLog
 
   describe "persistence" do
-    test "default is UTC" do
-      capture_log(fn -> Application.stop(:nerves_time_zones) end)
-      NervesTimeZones.Persistence.reset()
+    test "get returns what was set" do
+      :ok = NervesTimeZones.set_time_zone("America/Indiana/Indianapolis")
+      assert NervesTimeZones.get_time_zone() == "America/Indiana/Indianapolis"
+    end
 
-      Application.start(:nerves_time_zones)
+    test "reset restores default" do
+      :ok = NervesTimeZones.set_time_zone("Atlantic/Bermuda")
+      :ok = NervesTimeZones.reset_time_zone()
+
       assert NervesTimeZones.get_time_zone() == "Etc/UTC"
     end
 
@@ -19,6 +23,16 @@ defmodule NervesTimeZonesTest do
 
       Application.start(:nerves_time_zones)
       assert NervesTimeZones.get_time_zone() == "America/New_York"
+    end
+
+    test "default is UTC" do
+      # Clear out the time zone file
+      NervesTimeZones.reset_time_zone()
+      capture_log(fn -> Application.stop(:nerves_time_zones) end)
+
+      # This should be a fresh start
+      Application.start(:nerves_time_zones)
+      assert NervesTimeZones.get_time_zone() == "Etc/UTC"
     end
   end
 


### PR DESCRIPTION
This moves the configuration to flow through the main server's init
args. This isn't necessary now, but will help with upcoming changes.
