### PR TITLE
Support changing the default time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ following in your project's `config.exs`:
 config :nerves_time_zones, data_dir: "./tmp/nerves_time_zones"
 ```
 
+The default time zone is "Etc/UTC". If you want it to be something else, set it
+in the config like this:
+
+```elixir
+config :nerves_time_zones, default_time_zone: "Europe/Paris"
+```
+
 ## Database example
 
 If you just start up IEx, you may have seen something like this:

--- a/lib/nerves_time_zones.ex
+++ b/lib/nerves_time_zones.ex
@@ -42,6 +42,12 @@ defmodule NervesTimeZones do
   Reset the time zone to the default
 
   This cleans up any saved time zone information and reapplies the defaults.
+  The default time zone is "Etc/UTC", but this can be changed by adding
+  something like the following to your `config.exs`:
+
+  ```
+  config :nerves_time_zones, default_time_zone: "Asia/Tokyo"
+  ```
   """
   @spec reset_time_zone() :: :ok
   defdelegate reset_time_zone(), to: NervesTimeZones.Server


### PR DESCRIPTION
The default had been hard coded to "Etc/UTC". This adds support for
changing the default time zone to something else.

This is useful if you know that your device will only be used in one
time zone and you don't want to configure it at runtime.
