### PR TITLE
Update CI to OTP-24/Elixir 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
       - run: mix deps.get
       - run: mix format --check-formatted
       - run: mix deps.unlock --check-unused
-      - run: mix compile --warnings-as-errors
       - run: mix docs
       - run: mix hex.build
       - run: mix test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
         apk add build-base
 
 jobs:
-  build_elixir_1_11_otp_23:
+  build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.11.4-erlang-23.3.1-alpine-3.13.3
+      - image: hexpm/elixir:1.12.0-rc.1-erlang-24.0-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -45,8 +45,20 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_11_otp_23:
+    docker:
+      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test
+
 workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+Code.put_compiler_option(:warnings_as_errors, true)
+
 ExUnit.start()


### PR DESCRIPTION
- CI: Add OTP-24 and Elixir 1.12
- Always turn warnings to errors
