### PR TITLE
Simplify Makefile prints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ install_system_deps: &install_system_deps
 jobs:
   build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.12.0-rc.1-erlang-24.0-alpine-3.13.3
+      - image: hexpm/elixir:1.12.2-erlang-24.0.4-alpine-3.14.0
     <<: *defaults
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,11 @@ tzdata:
 $(OBJ): $(HEADERS) Makefile
 
 $(BUILD)/%.o: c_src/%.c
+	@echo "     CC $(notdir $@)"
 	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
 
 $(NIF): $(OBJ)
+	@echo "     LD $(notdir $@)"
 	$(CC) -o $@ $(ERL_LDFLAGS) $(LDFLAGS) $^
 
 $(PREFIX) $(BUILD):
@@ -71,3 +73,6 @@ clean:
 	$(RM) $(NIF) $(OBJ)
 
 .PHONY: all clean calling_from_make install tzdata
+
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:

--- a/tzdata.mk
+++ b/tzdata.mk
@@ -59,12 +59,15 @@ tzcode/version.h: tzcode/version
 ### End copied definitions
 
 $(BUILD)/zic: tzcode/zic.c tzcode/version.h
+	@echo " HOSTCC $(notdir $@)"
 	$(CC_FOR_BUILD) -o $@ tzcode/zic.c
 
 $(PREFIX)/zoneinfo: $(BUILD)/zic $(BUILD)/tzdata/.extracted Makefile
+	@echo "    ZIC $(notdir $@)"
 	cd $(BUILD)/tzdata && $(BUILD)/zic -d $@ $(ZIC_OPTIONS) $(TDATA)
 
 $(TZDATA_ARCHIVE_PATH):
+	@echo "   CURL $(notdir $@)"
 	curl -L $(TZDATA_URL) > $@
 
 $(BUILD)/tzdata/.extracted: $(TZDATA_ARCHIVE_PATH)
@@ -79,3 +82,6 @@ clean:
 	$(RM) -r $(BUILD) $(PREFIX)
 
 .PHONY: all clean calling_from_make
+
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:


### PR DESCRIPTION
This makes them prettier like other Nerves libraries do. To make them
verbose again, run `V=1 mix compile` or `V=1 make`.
