### PR TITLE
Update timezone database to 2022a

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule NervesTimeZones.MixProject do
   @app :nerves_time_zones
   @version "0.1.10"
   @source_url "https://github.com/nerves-time/nerves_time_zones"
-  @tzdata_version "2021e"
+  @tzdata_version "2022a"
   @tzdata_earliest_date System.os_time(:second) - 86400
   @tzdata_latest_date System.os_time(:second) + 10 * 365 * 86400
 


### PR DESCRIPTION
See [IANA 2022a NEWS](https://data.iana.org/time-zones/tzdb-2022a/NEWS) for
more info.

Notable changes
* Palestine will spring forward on 2022-03-27, not -03-26.
* zdump -v now outputs better failure indications
* Bug fixes for code that reads corrupted TZif data.