### PR TITLE
Ensure tzdata version change recompiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ nerves_time_zones-*.tar
 
 /tzdata*.tar.gz
 /tzcode/version.h
+/dl


### PR DESCRIPTION
Changing the tzdata version previously did not guarantee that the tzdb would get recompiled if all the existing compiled priv/zoneinfo and previously extracted tzdata were still around.

This would mean that a PR updating the TZ version would mistakenly pass CI if the previous cache was still around (see https://github.com/nerves-time/nerves_time_zones/pull/74)

This instead changes the build path and extraction to be version specific and forces recompilation when the version has changed.

(Broken off from #76)