### PR TITLE
Force zic to be compiled without gettext

### DIFF
--- a/tzdata.mk
+++ b/tzdata.mk
@@ -60,7 +60,7 @@ tzcode/version.h: tzcode/version
 
 $(BUILD)/zic: tzcode/zic.c tzcode/version.h
 	@echo " HOSTCC $(notdir $@)"
-	$(CC_FOR_BUILD) -o $@ tzcode/zic.c
+	$(CC_FOR_BUILD) -DHAVE_GETTEXT=0 -o $@ tzcode/zic.c
 
 $(PREFIX)/zoneinfo: $(BUILD)/zic $(BUILD)/tzdata/.extracted Makefile
 	@echo "    ZIC $(notdir $@)"


### PR DESCRIPTION
Gettext support isn't needed and the autodetection of whether it's
available doesn't work on MacOS by default.
