### PR TITLE
Sync writes to the timezone file; log write failures

### DIFF
--- a/lib/nerves_time_zones/persistence.ex
+++ b/lib/nerves_time_zones/persistence.ex
@@ -1,14 +1,24 @@
 defmodule NervesTimeZones.Persistence do
   @moduledoc false
 
+  require Logger
+
   @file_name "localtime"
 
   @spec save_time_zone(Path.t(), String.t()) :: :ok | {:error, File.posix()}
   def save_time_zone(data_dir, time_zone) do
     path = Path.join(data_dir, @file_name)
 
-    with :ok <- File.mkdir_p(data_dir) do
-      File.write(path, time_zone)
+    with :ok <- File.mkdir_p(data_dir),
+         :ok <- File.write(path, time_zone, [:sync]) do
+      :ok
+    else
+      {:error, reason} = error ->
+        Logger.error(
+          "Failed to save time zone, #{inspect(time_zone)}, to #{path}: #{inspect(reason)}"
+        )
+
+        error
     end
   end
 


### PR DESCRIPTION
This adds the `:sync` option when writing the time zone file to reduce
the chance of losing the write on an unexpected reboot.

Most of the code, though, beefs up reporting and testing of write
failures.
